### PR TITLE
Import example dataset 

### DIFF
--- a/scripts/import_dataset.sh
+++ b/scripts/import_dataset.sh
@@ -45,7 +45,7 @@ export VAPI_HOST="${powerai_ip}"
 
 # Try getting token to use CLI
 n=0
-until [[ $n -ge 10 ]]
+until [[ $n -ge 5 ]]
 do
    VAPI_TOKEN=$(vision users token --user admin --password ${password}) && break  # substitute your command here
    n=$[$n+1]

--- a/scripts/import_dataset.sh
+++ b/scripts/import_dataset.sh
@@ -16,20 +16,13 @@
 BASEDIR="$(dirname "$0")"
 source ${BASEDIR}/env.sh
 
-# Install aria and get example dataset zip file
-echo "Installing aria2..."
-apt-get -o Dpkg::Use-Pty=0 update -qq  || echo " RC${?} Got an error on update???"
-apt-get -o Dpkg::Use-Pty=0 install -qq aria2
+mkdir /tmp/load_dataset
+cd /tmp/load_dataset
 
-cd $HOME
 echo "Fetching example dataset from ${URLPAIVDATASET}"
-aria2c -q $URLPAIVDATASET
+wget -q -O Dataset.zip $URLPAIVDATASET
 
-# Uninstall aria2
-echo "Uninstalling aria2"
-apt-get -o Dpkg::Use-Pty=0 remove -qq aria2
-
-echo "SUCCESS: Downloaded ${DATASET_NAME} example data set successfully."
+echo "SUCCESS: Downloaded example data set successfully."
 
 git clone https://github.com/IBM/vision-tools.git
 
@@ -37,8 +30,8 @@ powerai_ip=$1
 password=$2
 
 # Set env variables to be able to use
-export PYTHONPATH=$PYTHONPATH:$HOME/vision-tools/lib
-PATH=$PATH:$HOME/vision-tools/cli
+export PYTHONPATH=$PYTHONPATH:/tmp/load_dataset/vision-tools/lib
+PATH=$PATH:/tmp/load_dataset/vision-tools/cli
 
 # Set VAPI_HOST to floating IP for UI
 export VAPI_HOST="${powerai_ip}"
@@ -64,7 +57,7 @@ echo "Attempting to import data set...."
 
 
 # Import Bowls_and_Plates.zip data set
-vision datasets import $HOME/${DATASET_NAME}
+vision datasets import /tmp/load_dataset/Dataset.zip
 exit_code=$?
 
 if [[ $exit_code -ne 0 ]]; then
@@ -73,4 +66,8 @@ if [[ $exit_code -ne 0 ]]; then
 else
     echo "Import of example data set was successful."
 fi
+
+# Clean up
+echo "Cleaning up files..."
+rm -fr /tmp/load_dataset
 

--- a/scripts/import_dataset.sh
+++ b/scripts/import_dataset.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -e
+# Copyright 2020. IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BASEDIR="$(dirname "$0")"
+source ${BASEDIR}/env.sh
+
+# Install aria and get example dataset zip file
+echo "Installing aria2..."
+apt-get -o Dpkg::Use-Pty=0 update -qq  || echo " RC${?} Got an error on update???"
+apt-get -o Dpkg::Use-Pty=0 install -qq aria2
+
+cd $HOME
+echo "Fetching example dataset from ${URLPAIVDATASET}"
+aria2c -q $URLPAIVDATASET
+
+# Uninstall aria2
+echo "Uninstalling aria2"
+apt-get -o Dpkg::Use-Pty=0 remove -qq aria2
+
+echo "SUCCESS: Downloaded ${DATASET_NAME} example data set successfully."
+
+git clone https://github.com/IBM/vision-tools.git
+
+powerai_ip=$1
+password=$2
+
+# Set env variables to be able to use
+export PYTHONPATH=$PYTHONPATH:$HOME/vision-tools/lib
+PATH=$PATH:$HOME/vision-tools/cli
+
+# Set VAPI_HOST to floating IP for UI
+export VAPI_HOST="${powerai_ip}"
+
+# Try getting token to use CLI
+n=0
+until [[ $n -ge 10 ]]
+do
+   VAPI_TOKEN=$(vision users token --user admin --password ${password}) && break  # substitute your command here
+   n=$[$n+1]
+   sleep 10
+done
+
+if [[ $n -eq 5 ]]; then
+    echo "Unable to get token needed to import example data set."
+    exit 1
+else
+    export VAPI_TOKEN
+    echo "Token created successfully."
+fi
+
+echo "Attempting to import data set...."
+
+
+# Import Bowls_and_Plates.zip data set
+vision datasets import $HOME/${DATASET_NAME}
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+    echo "ERROR: Example data set was unable to be imported."
+    exit 1
+else
+    echo "Import of example data set was successful."
+fi
+

--- a/scripts/import_dataset.sh
+++ b/scripts/import_dataset.sh
@@ -16,9 +16,11 @@
 BASEDIR="$(dirname "$0")"
 source ${BASEDIR}/env.sh
 
+# Create directory in /tmp to put everything in
 mkdir /tmp/load_dataset
 cd /tmp/load_dataset
 
+# Download example dataset
 echo "Fetching example dataset from ${URLPAIVDATASET}"
 wget -q -O Dataset.zip $URLPAIVDATASET
 
@@ -56,7 +58,7 @@ fi
 echo "Attempting to import data set...."
 
 
-# Import Bowls_and_Plates.zip data set
+# Import example data set
 vision datasets import /tmp/load_dataset/Dataset.zip
 exit_code=$?
 

--- a/scripts/import_dataset.sh
+++ b/scripts/import_dataset.sh
@@ -47,7 +47,7 @@ export VAPI_HOST="${powerai_ip}"
 n=0
 until [[ $n -ge 5 ]]
 do
-   VAPI_TOKEN=$(vision users token --user admin --password ${password}) && break  # substitute your command here
+   VAPI_TOKEN=$(vision users token --user admin --password ${password}) && break
    n=$[$n+1]
    sleep 10
 done

--- a/vm.tf
+++ b/vm.tf
@@ -38,9 +38,9 @@ variable "vision_tar_name" {
   default = "visual-insights-images-1.2.0.0.tar"
 }
 
-variable "example_dataset_name" {
-  description = "Name of example dataset to automatically import into Visual Insights."
-  default = "Bowls-and-Plates.zip"
+variable "example_dataset_url" {
+  description = "URL of example dataset to automatically import into Visual Insights."
+  default = "https://vision-cloud-trial.s3.direct.us-east.cloud-object-storage.appdomain.cloud/Bowls-and-Plates.zip"
 }
 
 variable "boot_image_name" {
@@ -215,8 +215,7 @@ export USERMGTIMAGE=vision-usermgt:${var.vision_version}
 export COS_BUCKET_BASE=${var.cos_bucket_base}
 export URLPAIVIMAGES="$${COS_BUCKET_BASE}/${var.vision_tar_name}"
 export URLPAIVDEB="$${COS_BUCKET_BASE}/${var.vision_deb_name}"
-export URLPAIVDATASET="$${COS_BUCKET_BASE}/${var.example_dataset_name}"
-export DATASET_NAME="${var.example_dataset_name}"
+export URLPAIVDATASET="${var.example_dataset_url}"
 ENDENVTEMPL
     destination = "/tmp/scripts/env.sh"
     connection {

--- a/vm.tf
+++ b/vm.tf
@@ -246,7 +246,6 @@ ENDENVTEMPL
       "/tmp/scripts/vision_start.sh",
       "/tmp/scripts/set_vision_pw.sh ${random_password.vision_password.result}",
       "/tmp/scripts/import_dataset.sh ${ibm_is_floating_ip.fip1.address} ${random_password.vision_password.result}",
-
       "rm -rf /tmp/scripts"
     ]
     connection {

--- a/vm.tf
+++ b/vm.tf
@@ -38,6 +38,11 @@ variable "vision_tar_name" {
   default = "visual-insights-images-1.2.0.0.tar"
 }
 
+variable "example_dataset_name" {
+  description = "Name of example dataset to automatically import into Visual Insights."
+  default = "Bowls-and-Plates.zip"
+}
+
 variable "boot_image_name" {
   description = "name of the base image for the virtual server (should be an Ubuntu 18.04 base)"
   default = "ibm-ubuntu-18-04-3-minimal-ppc64le-2"
@@ -210,6 +215,8 @@ export USERMGTIMAGE=vision-usermgt:${var.vision_version}
 export COS_BUCKET_BASE=${var.cos_bucket_base}
 export URLPAIVIMAGES="$${COS_BUCKET_BASE}/${var.vision_tar_name}"
 export URLPAIVDEB="$${COS_BUCKET_BASE}/${var.vision_deb_name}"
+export URLPAIVDATASET="$${COS_BUCKET_BASE}/${var.example_dataset_name}"
+export DATASET_NAME="${var.example_dataset_name}"
 ENDENVTEMPL
     destination = "/tmp/scripts/env.sh"
     connection {
@@ -238,6 +245,8 @@ ENDENVTEMPL
       "/tmp/scripts/ramdisk_tmp_destroy.sh",
       "/tmp/scripts/vision_start.sh",
       "/tmp/scripts/set_vision_pw.sh ${random_password.vision_password.result}",
+      "/tmp/scripts/import_dataset.sh ${ibm_is_floating_ip.fip1.address} ${random_password.vision_password.result}",
+
       "rm -rf /tmp/scripts"
     ]
     connection {


### PR DESCRIPTION
This script runs after the Visual Insights trial is set up, and uses the CLI to upload a Bowls_and_Plates.zip example dataset.

Some questions:
1) Referenced the fetch_vision.sh part for using aria2 to fetch Bowls_and_plates.zip from COS. Not sure if it was better to keep it all contained here and reinstall aria2 again to fetch Bowls_and_plate.zip here, or include it in fetch_vision.sh where you're already installing aria2 and just grab it there. 

2) Should the github repo in line 34 be passed in as a variable? Or is it okay to have it as a a direct URL? 

@mikehollinger @atthorst 